### PR TITLE
Update constructor and docstring `BBModel`

### DIFF
--- a/src/bb_models.jl
+++ b/src/bb_models.jl
@@ -1,40 +1,44 @@
-export AbstractBBModel, BBModel, obj, obj!
+export BBModel, obj, obj!
 
-abstract type AbstractBBModel{T, S} <: AbstractNLPModel{T, S} end
+"""Mutable struct `BBModel`
 
-"""Mutable struct BBModel
+Represents a black box optimization problem that follows the NLPModel API.
 
-Represents a black box optimization problem that follows the api described in `NLPModels`.
+The following constructors are available:
 
-`solver_function` is a function that takes an `AbstractNLPModel` and a `AbstractParameterSet` and runs a solver with thise two inputs.
+    BBModel(parameter_set, problems, solver_function, auxiliary_function; kwargs...)
+    BBModel(parameter_set, problems, solver_function, auxiliary_function, c, lcon, ucon; kwargs...)
 
-  Ex: ```julia
-  solver_function(nlp::AbstractNLPModel, p::AbstractParameterSet) = solve!(nlp, p;)  
-  ```
-`auxiliary_function` is a function that takes `ProblemMetrics` as a parameter and return a `Vector{Float64}`.
-  This function is the objective function that needs to be minimized/maximized as it represents how well your solver performed while solving a given problem.
-    Ex: ```julia
-    function aux_func(p_metric::ProblemMetrics)
-      T = Float64
-      median_time = T(median(get_times(p_metric)))
-      memory = T(get_memory(p_metric))
-      is_not_solved = T(!get_solved(p_metric))
-      counters = get_counters(p_metric)
-      return T[median_time + memory + T(counters.neval_obj) + (is_not_solved * median_time)]
-    end
-    ``` 
-  `c` is a function returning a `Vector{Float64}` that represents the constraints of the problem.
-  `problems` is a dictionary containing `AbstractNLPModels` to solve using the `solver_function` method.
-  `parameter_set` is the `AbstractParameterSet` of a given solver.
+- `parameter_set::AbstractParameterSet`: structure containing parameters information;
+- `problems::Vector{AbstractNLPModel}`: set of problem to run the benchmark on;
+- `solver_function::Function`: function that takes an `AbstractNLPModel` and a `AbstractParameterSet` and returns a [`GenericExecutionStats`](https://github.com/JuliaSmoothOptimizers/SolverCore.jl/blob/main/src/stats.jl).
+- `auxiliary_function::Function`: Given a `ProblemMetrics` returns a score as a Float64 (examples are `time_only`, `memory_only`, `sumfc`);
+
+For constrained problems:
+
+    lcon ≤ c(x) ≤ ucon
+
+- `c::Function`: constraint function;
+- `lcon::AbstractVector`: lower bound on the constraint;
+- `ucon::AbstractVector`: upper bound on the constraint.
+
+Additional keyword arguments are:
+
+- `x0::AbstractVector`: initial values for the parameters (by default `Float64.(values(parameter_set))`);
+- `lvar::AbstractVector`: lower bound on the the parameters (by default `Float64.(lower_bounds(parameter_set))`);
+- `uvar::AbstractVector`: upper bound on the the parameters (by default `Float64.(lower_bounds(parameter_set))`);
+- `name::String`: name of the problem (by default: "Generic").
+
+Note that if `x0` is not provided, the computations are run in `Vector{Float64}`.
 """
-mutable struct BBModel{F1 <: Function, F2 <: Function, P <: AbstractParameterSet, T, S} <:
-               AbstractBBModel{T, S}
+mutable struct BBModel{P <: AbstractParameterSet, T, S, F1 <: Function, F2 <: Function, F3 <: Function} <:
+               AbstractNLPModel{T, S}
   bb_meta::BBModelMeta
   meta::NLPModelMeta{T, S}
   counters::Counters
   solver_function::F1
   auxiliary_function::F2
-  c
+  c::F3
   problems::Dict{Int, Problem}
   parameter_set::P
 end
@@ -42,113 +46,55 @@ end
 NLPModels.show_header(io::IO, ::BBModel) = println(io, "BBModel - Black Box Optimization Model")
 
 function BBModel(
-  parameter_set::P,
-  solver_function::F1,
-  auxiliary_function::F2,
-  problems::Vector{M};
-  lvar = lower_bounds(parameter_set),
-  uvar = upper_bounds(parameter_set),
-  kwargs...,
-) where {P <: AbstractParameterSet, F1 <: Function, F2 <: Function, M <: AbstractNLPModel}
-  return BBModel(
-    values(parameter_set),
-    solver_function,
-    auxiliary_function,
-    problems,
-    parameter_set,
-    lvar,
-    uvar;
-    kwargs...,
-  )
-end
-
-function BBModel(
-  x0::AbstractVector,
-  solver_function::F1,
-  auxiliary_function::F2,
+  parameter_set::AbstractParameterSet,
   problems::Vector{M},
-  parameter_set::P,
-  lvar::AbstractVector,
-  uvar::AbstractVector;
+  solver_function::Function,
+  auxiliary_function::Function = time_only;
+  x0::S = Float64.(values(parameter_set)),
+  lvar::S = eltype(x0).(lower_bounds(parameter_set)),
+  uvar::S = eltype(x0).(upper_bounds(parameter_set)),
   name::String = "generic-BBModel",
-) where {P <: AbstractParameterSet, F1 <: Function, F2 <: Function, M <: AbstractNLPModel}
+) where {M <: AbstractNLPModel, S}
   length(problems) > 0 || error("No problems given")
   nvar = length(x0)
+  @lencheck nvar lvar uvar
   bbmeta = BBModelMeta(parameter_set)
-  meta_x0 = Vector{Float64}([Float64(i) for i in x0])
-  meta_lvar = Vector{Float64}([Float64(i) for i in lvar])
-  meta_uvar = Vector{Float64}([Float64(i) for i in uvar])
-  meta = NLPModelMeta(nvar; x0 = meta_x0, lvar = meta_lvar, uvar = meta_uvar, name = name)
+  meta = NLPModelMeta(nvar; x0 = x0, lvar = lvar, uvar = uvar, name = name)
   problems =
-    Dict{Int, Problem}(id => Problem(id, p, eps(Float64)) for (id, p) ∈ enumerate(problems))
+    Dict{Int, Problem}(id => Problem(id, p, eps()) for (id, p) ∈ enumerate(problems))
   return BBModel(
     bbmeta,
     meta,
     Counters(),
     solver_function,
     auxiliary_function,
-    x -> Float64[],
+    x -> T[],
     problems,
     parameter_set,
   )
 end
 
-# Constructor with constraints
 function BBModel(
-  parameter_set::P,
-  solver_function::F1,
-  auxiliary_function::F2,
-  c::Function,
-  lcon::Vector{Float64},
-  ucon::Vector{Float64},
-  problems::Vector{M};
-  lvar = lower_bounds(parameter_set),
-  uvar = upper_bounds(parameter_set),
-  kwargs...,
-) where {P <: AbstractParameterSet, F1 <: Function, F2 <: Function, M <: AbstractNLPModel}
-  x0 = values(parameter_set)
-  return BBModel(
-    x0,
-    solver_function,
-    auxiliary_function,
-    c,
-    lcon,
-    ucon,
-    problems,
-    parameter_set,
-    lvar,
-    uvar;
-    kwargs...,
-  )
-end
-
-function BBModel(
-  x0::AbstractVector,
-  solver_function::F1,
-  auxiliary_function::F2,
-  c::Function,
-  lcon::Vector{Float64},
-  ucon::Vector{Float64},
+  parameter_set::AbstractParameterSet,
   problems::Vector{M},
-  parameter_set::P,
-  lvar::AbstractVector,
-  uvar::AbstractVector;
+  solver_function::Function,
+  auxiliary_function::Function,
+  c::Function,
+  lcon::S,
+  ucon::S;
+  x0::S = eltype(S).(values(parameter_set)),
+  lvar::S = eltype(S).(lower_bounds(parameter_set)),
+  uvar::S = eltype(S).(upper_bounds(parameter_set)),
   name::String = "generic-BBModel",
-) where {P <: AbstractParameterSet, F1 <: Function, F2 <: Function, M <: AbstractNLPModel}
+) where {M <: AbstractNLPModel, S}
   length(problems) > 0 || error("No problems given")
-  @lencheck ncon ucon lcon
-  nvar = length(x0)
+  nvar, ncon = length(x0), length(lcon)
+  @lencheck ncon ucon
+  @lencheck nvar lvar uvar
   bbmeta = BBModelMeta(parameter_set)
-  meta = NLPModelMeta(
-    nvar;
-    x0 = Vector{Float64}([Float64(i) for i in x0]),
-    lvar = lvar,
-    uvar = uvar,
-    name = name,
-  )
+  meta = NLPModelMeta(nvar; x0 = x0, ncon = ncon, lvar = lvar, uvar = uvar, lcon = lcon, ucon = ucon, name = name)
   problems =
-    Dict{Int, Problem}(id => Problem(id, p, eps(Float64)) for (id, p) ∈ enumerate(problems))
-
+    Dict{Int, Problem}(id => Problem(id, p, eps()) for (id, p) ∈ enumerate(problems))
   return BBModel(
     bbmeta,
     meta,

--- a/test/bbmodels_test.jl
+++ b/test/bbmodels_test.jl
@@ -4,6 +4,29 @@ function solver_func(nlp::AbstractNLPModel, p::AbstractVector)
   @info "bbmodel vector: $p"
 end
 
+@testset "Testing multi-precision BBModels" verbose = true for T in (Float32, Float64)
+  param_set = R2ParameterSet()
+  x0 = T.(values(param_set))
+  nlp = BBModel(param_set, problems, solver_func, time_only, x0 = x0)
+  @test eltype(nlp.meta.x0) == T
+  @test eltype(nlp.meta.lvar) == T
+  @test eltype(nlp.meta.uvar) == T
+end
+
+@testset "Testing multi-precision BBModels" verbose = true for T in (Float32, Float64)
+  param_set = R2ParameterSet()
+  c = x -> [x[1]]
+  con = zeros(T, 1)
+  x0 = T.(values(param_set))
+  nlp = BBModel(param_set, problems, solver_func, time_only, c, con, con, x0 = x0)
+  @test eltype(nlp.meta.x0) == T
+  @test eltype(nlp.meta.lvar) == T
+  @test eltype(nlp.meta.uvar) == T
+  @test eltype(nlp.meta.lcon) == T
+  @test eltype(nlp.meta.ucon) == T
+  @test eltype(cons(nlp, nlp.meta.x0)) == T
+end
+
 function tailored_aux_func(p_metric::ProblemMetrics)
   median_time = median(get_times(p_metric))
   memory = get_memory(p_metric)
@@ -17,7 +40,7 @@ end
   T = Float64
   I = Int64
   param_set = R2ParameterSet()
-  nlp = BBModel(param_set, solver_func, aux_func, problems)
+  nlp = BBModel(param_set, problems, solver_func, aux_func)
 
   @testset "Test BBModels attributes" verbose = true begin
     x = nlp.meta.x0


### PR DESCRIPTION
@MonssafToukal 
I tried to simplify the constructors, and respect the typing constraint of the NLPModel API.
Removed `AbstractBBModel` as I didn't see a direct use of it.
After #27 , we could also add that `obj` return an element of `eltype(x)`.